### PR TITLE
Fix Anon Team Names

### DIFF
--- a/bin/jamstats
+++ b/bin/jamstats
@@ -113,7 +113,7 @@ else:
 
 if args.anonymizeteams:
     print("Anonymizing teams.")
-    derby_game.anonymize_teams()
+    derby_game.anonymize_team_names()
 
 if args.teamcolor1 is not None:
     derby_game.set_team_color_1(args.teamcolor1)


### PR DESCRIPTION
Call correct function name anonymize_team_names instead of anonymize_teams - one of the bugs in #76 