### PR TITLE
added an optional argument for jamstats server ip

### DIFF
--- a/bin/jamstats
+++ b/bin/jamstats
@@ -16,7 +16,10 @@ from jamstats.util.resources import get_jamstats_version
 from jamstats.web import statserver
 import logging
 import sys
+from os.path import exists
 from gooey import Gooey, GooeyParser
+from attrdict import AttrDict
+
 
 logger = logging.Logger(__name__)
 
@@ -47,12 +50,15 @@ def add_args(parser, is_gooey):
     parser.add_argument('--scoreboardserver', type=str,
                         help="server:port to connect to, e.g., localhost:8000. If this argument is specified, will connect to a server. Either this or jsonfile must be specified")
     parser.add_argument('--outfile', type=argparse.FileType('w'),
-                        help='File to write. If this argument is specified, will write output to a file. '
+                        help='File to write. If this argument is specified, will write a PDF or TSV file. '
                         'If ends with ".pdf", write plots to a PDF. If ".tsv" or ".txt" '
                         'write data to tab-separated values file. Either this or jamstatsport must be specified.')
     parser.add_argument('--jamstatsport', type=int,
-                        help='Port to serve to. If this argument is specified, will serve output to a webserver '
+                        help='Port to serve to, e.g., 8080. If this argument is specified, will serve output to a webserver '
                         'on the specified port. Either this or outfile must be specified unless input is jsonfile.')
+    parser.add_argument('--jamstatsip', type=str,
+                        help='IP address to serve to, e.g., "192.168.4.21" or "localhost". This argument is optional even if jamstatsport is specified. '
+                        'If not specified, will infer your local IP address.')
     parser.add_argument('--anonymize', action="store_true",
                         help="Replace actual skater names with random pregenerated ones?")
     parser.add_argument('--anonymizeteams', action="store_true",
@@ -80,7 +86,24 @@ def add_args(parser, is_gooey):
     return args
 
 if len(sys.argv) == 1:
+    # no args, so run the GUI
     args = gui_args()
+elif len(sys.argv) == 2:
+    # one arg, so try to treat it as a json file, and fail if it's not.
+    # This option makes it possible to drag-and-drop on Windows.
+    if exists(sys.argv[1]):
+        args = AttrDict()
+        args.jsonfile = open(sys.argv[1])
+        args.debug = False
+        args.scoreboardserver = None
+        args.anonymizeteams = False
+        args.anonymize = False
+        args.teamcolor1 = None
+        args.teamcolor2 = None
+        args.jamstatsport = None
+        args.outfile = None
+    else:
+        sys.exit(f"File {sys.argv[1]} does not exist")
 else:
     args = cmdline_args()
 
@@ -98,18 +121,18 @@ if args.debug:
 connect_to_server = False
 if args.scoreboardserver:
     try:
-        server, port = args.scoreboardserver.split(":")
-        port = int(port)
+        scoreboardserver, scoreboardport = args.scoreboardserver.split(":")
+        scoreboardport = int(scoreboardport)
         connect_to_server = True
     except Exception as e:
         print(f"Tried to interpret {args.scoreboardserver} as server:port but failed: {e}")
 
 if connect_to_server:
-    print(f"Connecting to server {server}, port {port}...")
+    print(f"Connecting to server {scoreboardserver}, port {scoreboardport}...")
     try:
-        derby_game = load_inprogress_game_from_server(server, port)
+        derby_game = load_inprogress_game_from_server(scoreboardserver, scoreboardport)
     except Exception as e:
-        sys.exit(f"Failed to download in-game data from server {server}:{port}: {e}")
+        sys.exit(f"Failed to download in-game data from server {scoreboardserver}:{scoreboardport}: {e}")
 else:
     try:
         derby_game = load_derby_game_from_json_file(args.jsonfile.name)
@@ -132,11 +155,12 @@ if args.jamstatsport is not None:
     statserver.set_game(derby_game)
     kwargs = {
         "anonymize_names": args.anonymize,
-        "theme": args.theme
+        "theme": args.theme,
+        "jamstats_ip": args.jamstatsip,
     }
     if connect_to_server:
-        kwargs["scoreboard_port"] = port
-        kwargs["scoreboard_server"] = server
+        kwargs["scoreboard_port"] = scoreboardport
+        kwargs["scoreboard_server"] = scoreboardserver
     
     statserver.start(args.jamstatsport, **kwargs)
 else:

--- a/src/jamstats/web/statserver.py
+++ b/src/jamstats/web/statserver.py
@@ -57,16 +57,30 @@ PLOT_NAME_FUNC_MAP = {
     "Team 2 Skaters": plot_skater_stats_team2,
 }
 
-def start(port: int, debug: bool = True, scoreboard_server: str = None,
+def start(port: int, jamstats_ip: str = None, debug: bool = True, scoreboard_server: str = None,
           scoreboard_port: int = None, anonymize_names=False,
           theme="white") -> None:
+    """
+
+    Args:
+        port (int): port to start the jamstats server on
+        jamstats_ip (str, optional): IP address to start on. Defaults to None. If None, will infer
+        debug (bool, optional): _description_. Defaults to True.
+        scoreboard_server (str, optional): _description_. Defaults to None.
+        scoreboard_port (int, optional): _description_. Defaults to None.
+        anonymize_names (bool, optional): _description_. Defaults to False.
+        theme (str, optional): _description_. Defaults to "white".
+    """
     matplotlib.use('Agg')
     app.plotname_image_map = {}
     app.plotname_time_map = {}
     prepare_to_plot(theme=theme)
     app.scoreboard_server = scoreboard_server
     app.scoreboard_port = scoreboard_port
-    app.ip = socket.gethostbyname(socket.gethostname())
+    if jamstats_ip:
+        app.ip = jamstats_ip
+    else:
+        app.ip = socket.gethostbyname(socket.gethostname())
     app.port = port
     app.anonymize_names=anonymize_names
     print(f"Starting jamstats server at http://{app.ip}:{app.port}")
@@ -85,7 +99,7 @@ def index():
         seconds_since_update = (datetime.now() - app.game_update_time).total_seconds()
         if  seconds_since_update >= MIN_REQUERY_SERVER_SECONDS:
             logger.debug(f"Connecting to server {app.scoreboard_server}, "
-                         "port {app.scoreboard_port}...")
+                         f"port {app.scoreboard_port}...")
             try:
                 derby_game = load_inprogress_game_from_server(
                     app.scoreboard_server, app.scoreboard_port)


### PR DESCRIPTION
Close #83. Adds an argument to capture the IP address (can be "localhost") you want to start the jamstats server on.

Also restores the ability to drag-and-drop a json file on to the jamstats EXE on Windows.