### PR TITLE
Defensive coding around missing Id column

### DIFF
--- a/src/jamstats/data/game_data.py
+++ b/src/jamstats/data/game_data.py
@@ -250,7 +250,8 @@ class DerbyGame:
 
         # now, make a row for anyone who was a pivot who became jammer via star pass
 
-        pdf_jams_with_star_passes = pdf_jams_data[pdf_jams_data[f"StarPass_{team_number}"]]
+        pdf_jams_with_star_passes = pdf_jams_data[pdf_jams_data[
+            f"StarPass_{team_number}"] == True]
         pivots_who_jammed = list(set(pdf_jams_with_star_passes[f"pivot_name_{team_number}"]))
         jammers_who_only_pivotjammed = [x for x in pivots_who_jammed
                                        if x not in set(pdf_jammer_data.Jammer)]

--- a/src/jamstats/data/json_to_pandas.py
+++ b/src/jamstats/data/json_to_pandas.py
@@ -478,6 +478,13 @@ def extract_roster(pdf_game_state: pd.DataFrame,
     pdf_roster = pdf_game_state_roster.pivot(index="skater", columns="roster_key", values="value")
     logger.debug("pdf_roster columns: " + str(pdf_roster.columns) + 
                  ". Before dropping nulls, length: " + str(len(pdf_roster)))
+    # paranoia. Somehow a quadmedia game had no Id column, so if that happens
+    # write out a message
+    if "Id" not in pdf_roster.columns:
+        error_message = "No Id column in roster. This is a bug in the game file."
+        error_message += "Roster columns: " + str(pdf_roster.columns)
+        logger.error(error_message)
+        raise ValueError(error_message)
     pdf_roster = pdf_roster[pdf_roster.Id.notnull()]
     logger.debug("After dropping nulls, length: " + str(len(pdf_roster)))
 


### PR DESCRIPTION
Quad Media reported Issue #156, which looks to be somehow a missing "Id" column from the roster. I haven't seen a file that produces that error, myself, but I want to be prepared for it in the future. 

Adding some defensive coding around that problem, so a better error gets displayed.