### PR TITLE
removed attrdict dependency

### DIFF
--- a/bin/jamstats
+++ b/bin/jamstats
@@ -21,7 +21,6 @@ import logging
 import sys
 from os.path import exists
 from gooey import Gooey, GooeyParser
-from attrdict import AttrDict
 import time
 import sys, traceback
 import _thread
@@ -107,6 +106,16 @@ def add_and_parse_args(parser, is_gooey=False):
         sys.exit()
     return args
 
+
+class AttrObj:
+    """
+    This is a trivial class that just exists to accept attributes,
+    to stand in for the ArgParse args object when we're not using ArgParse.
+    """
+    def __init__(self):
+        pass
+
+
 def __main__():
     if len(sys.argv) == 1:
         # no args, so run the GUI
@@ -119,7 +128,7 @@ def __main__():
         # so try to treat it as a json file, and fail if it's not.
         # This option makes it possible to drag-and-drop on Windows.
         if exists(sys.argv[1]):
-            args = AttrDict()
+            args = AttrObj()
             args.jsonfile = open(sys.argv[1])
             args.debug = False
             args.scoreboardserver = None

--- a/bin/jamstats-nogui
+++ b/bin/jamstats-nogui
@@ -20,7 +20,6 @@ from jamstats.data.json_to_pandas import load_json_derby_game
 import logging
 import sys
 from os.path import exists
-from attrdict import AttrDict
 import time
 import sys, traceback
 import _thread
@@ -92,6 +91,16 @@ def add_and_parse_args(parser, is_gooey=False):
         sys.exit()
     return args
 
+
+class AttrObj:
+    """
+    This is a trivial class that just exists to accept attributes,
+    to stand in for the ArgParse args object when we're not using ArgParse.
+    """
+    def __init__(self):
+        pass
+
+
 def __main__():
     if len(sys.argv) == 2 and sys.argv[1] != "-h" \
       and sys.argv[1] != "-v" \
@@ -101,7 +110,7 @@ def __main__():
         # so try to treat it as a json file, and fail if it's not.
         # This option makes it possible to drag-and-drop on Windows.
         if exists(sys.argv[1]):
-            args = AttrDict()
+            args = AttrObj()
             args.jsonfile = open(sys.argv[1])
             args.debug = False
             args.scoreboardserver = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-attrdict>=2.0.1
 wxpython==4.2.0
 pandas>=1.3.5
 seaborn>=0.12.1
 flask>=2.2.2
-attrdict>=2.0.1
 gooey>=1.0.8.1
 websocket-client>=1.2.1
 Flask-SocketIO>=5.3.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     include_package_data=True,
     packages=find_packages('src', exclude=['test']),
     scripts=['bin/jamstats', 'bin/jamstats-nogui'],
-    install_requires=['pandas>=1.3.4', 'seaborn>=0.11.2', 'flask>=2.2.2', 'attrdict>=2.0.1',
+    install_requires=['pandas>=1.3.4', 'seaborn>=0.11.2', 'flask>=2.2.2',
                       'wxpython==4.2.0',
 		      'gooey>=1.0.8.1', 'websocket-client>=1.2.1',
 		      'Flask-SocketIO>=5.3.2', 'python-engineio>=4.3.4', 'gevent>=22.10.2', 'gevent-websocket>=0.10.1',

--- a/setup_nogui.py
+++ b/setup_nogui.py
@@ -9,7 +9,7 @@ setup(
     include_package_data=True,
     packages=['jamstats'],
     scripts=['bin/jamstats-nogui'],
-    install_requires=['pandas>=1.3.4', 'seaborn>=0.11.2', 'flask>=2.2.2', 'attrdict>=2.0.1', 'websocket-client>=1.2.1',
+    install_requires=['pandas>=1.3.4', 'seaborn>=0.11.2', 'flask>=2.2.2', 'websocket-client>=1.2.1',
 		      'Flask-SocketIO>=5.3.2', 'python-engineio>=4.3.4', 'gevent>=22.10.2', 'gevent-websocket>=0.10.1'],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Got rid of the dependency on attrdict, which was causing problems in Python 3.10+. Dependency was only in `bin/jamstats` and `bin/jamstats_nogui`, where I was using it to dummy up an object that looks like the ArgParse args object. Replaced with a trivial class that does nothing and can take attributes.